### PR TITLE
create_ca.sh, create_server.sh: Add missing semicolon

### DIFF
--- a/create_ca.sh
+++ b/create_ca.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-die() { echo "$*" >&2 ; exit 1 }
+die() { echo "$*" >&2 ; exit 1; }
 
 test -e config.sh || die "config.sh missing"
 . config.sh

--- a/create_server.sh
+++ b/create_server.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-die() { echo "$*" >&2 ; exit 1 }
+die() { echo "$*" >&2 ; exit 1; }
 
 test -e config.sh || die "config.sh missing"
 . config.sh


### PR DESCRIPTION
Commit e8a50eda504 ("Cosmetics") erroneously removed a semicolon at the end of a block in two scripts, effectively invalidating the syntax. Revert that part.

Fixes #2