### PR TITLE
Fix for OpenSSL < 1.1.1r compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.tmp
-
 *.pem
 eduroam_crl.der
-
+eduroamCA.srl
 config.sh
 

--- a/create_server.sh
+++ b/create_server.sh
@@ -40,11 +40,14 @@ ${crl_url:+crlDistributionPoints = URI:$crl_url}
 
 __EOF__
 
+# -CAcreateserial required for OpenSSL < 1.1.1r only
+
 openssl x509 \
     -in server.certreq.pem.tmp -req \
     -CA eduroamCA.cert.pem -CAkey eduroamCA.key.pem \
     -out server.cert.pem \
     -extfile openssl.ext.tmp \
-    -days 825
+    -days 825 \
+    -CAcreateserial
 
 rm *.tmp


### PR DESCRIPTION
OpenSSL versions before 1.1.1r require either -CAserial or -CAcreateserial when used with the -CA. This was changed by [1].

Add -CAcreateserial to support these elder OpenSLL versions.

[1]: https://github.com/openssl/openssl/commit/55eafed6fb

Fixes #3